### PR TITLE
fix: mark Alembic migration variables as public to resolve CodeQL warnings

### DIFF
--- a/backend/alembic/versions/20250103_1200_001_initial_schema.py
+++ b/backend/alembic/versions/20250103_1200_001_initial_schema.py
@@ -19,6 +19,9 @@ down_revision: str | None = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+# Mark as public to indicate these variables are used by Alembic via introspection
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on", "upgrade", "downgrade"]
+
 
 def upgrade() -> None:
     # Create market_snapshots table


### PR DESCRIPTION
## Summary
Fixes CodeQL code scanning alerts #10, #11, #12, #13 for unused global variables in Alembic migration.

## Problem
CodeQL flagged the standard Alembic migration metadata variables as unused:
- `revision` (alert #10)
- `down_revision` (alert #11)
- `branch_labels` (alert #12)
- `depends_on` (alert #13)

These variables are required by Alembic and are read via introspection, but static analysis tools see them as unused in the code.

## Solution
Added `__all__` to explicitly mark these variables as part of the module's public API. This is the recommended solution per CodeQL documentation:

> "A global (module-level) variable is defined (by an assignment) but never used and is not explicitly made public by inclusion in the `__all__` list."

```python
# Mark as public to indicate these variables are used by Alembic via introspection
__all__ = ["revision", "down_revision", "branch_labels", "depends_on", "upgrade", "downgrade"]
```

## Testing
- [x] Pre-commit hooks pass (ruff, ruff format, mypy)
- [x] Python syntax validation passes
- [x] Alembic compatibility maintained (variables remain named exactly as required)

## Impact
- ✅ Resolves 4 CodeQL security alerts
- ✅ Maintains full Alembic functionality
- ✅ Improves code quality score
- ✅ Documents intentional usage pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)