### PR TITLE
fix: add token and file existence checks for Codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
-        if: always()
+        if: always() && hashFiles('backend/coverage.xml') != ''
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./backend/coverage.xml
           flags: backend
           name: backend-${{ matrix.python-version }}
@@ -107,8 +108,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
-        if: always()
+        if: always() && hashFiles('frontend/coverage/coverage-final.json') != ''
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend/coverage/coverage-final.json
           flags: frontend
           name: frontend-${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
Fixes CI failures with Codecov uploads by adding authentication token and file existence validation.

## Problems Fixed

### 1. Protected Branch Authentication Error
```
error - Upload failed: {"message":"Token required because branch is protected"}
```
**Root Cause**: Codecov uploads require explicit token for protected branches
**Solution**: Added `token: ${{ secrets.CODECOV_TOKEN }}` to both uploads

### 2. Missing Coverage Files Error
```
warning - Some files were not found --- {"not_found_files": ["frontend/coverage/coverage-final.json"]}
error - No coverage reports found
```
**Root Cause**: Frontend has placeholder tests (`echo "No tests yet"`) that don't generate coverage
**Solution**: Added file existence check using `hashFiles()` before upload

## Changes

### Backend Coverage Upload
```yaml
- name: Upload coverage to Codecov
  uses: codecov/codecov-action@v5
  if: always() && hashFiles('backend/coverage.xml') != ''
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    files: ./backend/coverage.xml
    flags: backend
    name: backend-${{ matrix.python-version }}
```

### Frontend Coverage Upload
```yaml
- name: Upload coverage to Codecov
  uses: codecov/codecov-action@v5
  if: always() && hashFiles('frontend/coverage/coverage-final.json') != ''
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    files: ./frontend/coverage/coverage-final.json
    flags: frontend
    name: frontend-${{ matrix.node-version }}
```

## Behavior
- ✅ **Still runs on test failure**: `if: always()` ensures upload attempt even when tests fail
- ✅ **Gracefully skips missing files**: `hashFiles() != ''` prevents errors when coverage doesn't exist
- ✅ **Authenticates properly**: `CODECOV_TOKEN` allows uploads from protected branches
- ✅ **Ready for real tests**: Will automatically upload coverage once tests are implemented

## Testing
- [x] Pre-commit hooks pass
- [x] YAML syntax valid
- [ ] CI checks pending (will verify token and file checks work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)