### PR TITLE
feat: separate test results upload per Codecov best practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,24 @@ jobs:
       - name: Run tests with pytest
         run: |
           cd backend
-          pytest tests/ -v --cov=. --cov-report=xml --junitxml=junit.xml || test $? -eq 5 && echo "No tests yet - skipping"
+          pytest tests/ -v --cov=. --cov-report=xml --junitxml=junit.xml -o junit_family=legacy || test $? -eq 5 && echo "No tests yet - skipping"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         if: always() && hashFiles('backend/coverage.xml') != ''
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./backend/coverage.xml,./backend/junit.xml
+          files: ./backend/coverage.xml
           flags: backend
           name: backend-${{ matrix.python-version }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./backend/junit.xml
+          flags: backend
 
   frontend:
     name: Frontend (TypeScript)
@@ -106,14 +114,22 @@ jobs:
           cd frontend
           pnpm test:ci
 
-      - name: Upload coverage and test results to Codecov
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         if: always() && hashFiles('frontend/coverage/coverage-final.json') != ''
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./frontend/coverage/coverage-final.json,./frontend/test-results.xml
+          files: ./frontend/coverage/coverage-final.json
           flags: frontend
           name: frontend-${{ matrix.node-version }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./frontend/test-results.xml
+          flags: frontend
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
Updated CI to follow Codecov's recommended pattern by separating coverage and test results uploads.

## Changes

### Backend
- ✅ Added `-o junit_family=legacy` to pytest command (per Codecov docs)
- ✅ Split coverage upload (codecov-action@v5) and test results upload (test-results-action@v1)
- ✅ Coverage: `coverage.xml` only
- ✅ Test results: `junit.xml` via dedicated action

### Frontend  
- ✅ Split coverage upload (codecov-action@v5) and test results upload (test-results-action@v1)
- ✅ Coverage: `coverage-final.json` only
- ✅ Test results: `test-results.xml` via dedicated action

## Benefits
- Better separation of concerns (coverage vs test analytics)
- Improved test analytics visualization in Codecov
- Follows current Codecov documentation and best practices
- Enables Codecov's test insights features

## Reference
Following pattern from: https://docs.codecov.com/docs/test-result-analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)