### PR TITLE
feat: add separate patch coverage checks for frontend and backend

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,6 +22,20 @@ coverage:
         target: 80%
         threshold: 2%
 
+      # Backend patch coverage
+      backend:
+        target: 80%
+        threshold: 2%
+        flags:
+          - backend
+
+      # Frontend patch coverage
+      frontend:
+        target: 80%
+        threshold: 2%
+        flags:
+          - frontend
+
       # WebSocket Infrastructure - Phase 2 Critical Files
       websocket_infra:
         target: 80%


### PR DESCRIPTION
## Summary
Added dedicated patch coverage status checks for backend and frontend to provide granular visibility into patch coverage by domain.

## Changes

### Patch Coverage Checks Added
All with 80% target, 2% threshold:

✅ **codecov/patch/default** - Overall patch coverage for all new code  
✅ **codecov/patch/backend** - Backend-specific patch coverage (uses `backend` flag)  
✅ **codecov/patch/frontend** - Frontend-specific patch coverage (uses `frontend` flag)  
✅ **codecov/patch/websocket_infra** - WebSocket infrastructure files (5% threshold)

## Benefits

### Granular Visibility
- See backend vs frontend coverage separately in PR status checks
- Identify which domain needs more test coverage
- Default check ensures overall code quality baseline

### Better Accountability
- Backend changes tracked independently
- Frontend changes tracked independently  
- Critical infrastructure (WebSocket) has dedicated tracking

### PR Experience
PRs will now show 4 separate patch coverage checks:
```
✅ codecov/patch/default
✅ codecov/patch/backend
✅ codecov/patch/frontend
✅ codecov/patch/websocket_infra
```

## Configuration
```yaml
patch:
  default:
    target: 80%
    threshold: 2%

  backend:
    target: 80%
    threshold: 2%
    flags:
      - backend

  frontend:
    target: 80%
    threshold: 2%
    flags:
      - frontend

  websocket_infra:
    target: 80%
    threshold: 5%
    paths:
      - backend/infrastructure/kalshi/websocket_client.py
      - backend/infrastructure/polling/gap_filler.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)